### PR TITLE
Pass hash of options down to zip_tricks streamer

### DIFF
--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -12,8 +12,8 @@ require "zipline/zip_generator"
 #   end
 # end
 module Zipline
-  def zipline(files, zipname = 'zipline.zip')
-    zip_generator = ZipGenerator.new(files)
+  def zipline(files, zipname = 'zipline.zip', **kwargs_for_new)
+    zip_generator = ZipGenerator.new(files, **kwargs_for_new)
     headers['Content-Disposition'] = ContentDisposition.format(disposition: 'attachment', filename: zipname)
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -3,8 +3,9 @@
 module Zipline
   class ZipGenerator
     # takes an array of pairs [[uploader, filename], ... ]
-    def initialize(files)
+    def initialize(files, **kwargs_for_new)
       @files = files
+      @kwargs_for_new = kwargs_for_new
     end
 
     #this is supposed to be streamed!
@@ -29,7 +30,7 @@ module Zipline
       # this might pose a problem. Unlikely that it will be an issue here though.
       write_buffer_size = 16 * 1024
       write_buffer = ZipTricks::WriteBuffer.new(fake_io_writer, write_buffer_size)
-      ZipTricks::Streamer.open(write_buffer) do |streamer|
+      ZipTricks::Streamer.open(write_buffer, **@kwargs_for_new) do |streamer|
         @files.each do |file, name, options = {}|
           handle_file(streamer, file, name.to_s, options)
         end


### PR DESCRIPTION
## Related Issue(s)

https://github.com/Loomly/calendy/pull/8477

## Brief Summary of Issue

We need to support the `auto_rename_duplicate_filenames` option from `zip_tricks` and since the upstream PR on `zipline` is taking a while to be merged in we need this fork to fix the bug we have with duplicated filenames. More info here: https://github.com/Loomly/calendy/pull/8477#issuecomment-1279391321